### PR TITLE
Include JDK 21 in list of EA builds

### DIFF
--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -45,7 +45,7 @@ class ListOpenJavaDevelopmentKits {
   static final String SA = System.getProperty("SA", "18");
 
   /** Early-Access Releases, as comma separated names. */
-  static final String EA = System.getProperty("EA", "20,genzgc,jextract,loom,metropolis,panama,valhalla");
+  static final String EA = System.getProperty("EA", "21,20,genzgc,jextract,loom,metropolis,panama,valhalla");
 
   /** Include archived releases flag. */
   static final boolean ARCHIVES = Boolean.getBoolean("ARCHIVES");


### PR DESCRIPTION
Local execution of `ListOpenJavaDevelopmentKits` after the change:

```diff
diff --git a/jdk.java.net-uri.properties b/jdk.java.net-uri.properties
--- a/jdk.java.net-uri.properties	(revision b593a4b3090aa27e0ca064bbc2d75a95f9b3b144)
+++ b/jdk.java.net-uri.properties	(date 1670748634487)
@@ -60,6 +60,11 @@
 20,20-valhalla+20-75,macos,aarch64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_macos-aarch64_bin.tar.gz
 20,20-valhalla+20-75,macos,x64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_macos-x64_bin.tar.gz
 20,20-valhalla+20-75,windows,x64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_windows-x64_bin.zip
+21,21-ea+1,linux,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-aarch64_bin.tar.gz
+21,21-ea+1,linux,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-x64_bin.tar.gz
+21,21-ea+1,macos,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-aarch64_bin.tar.gz
+21,21-ea+1,macos,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-x64_bin.tar.gz
+21,21-ea+1,windows,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_windows-x64_bin.zip
 #
 # Early-Access Releases (Alias)
 #
@@ -68,11 +73,16 @@
 20,latest,macos,aarch64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_macos-aarch64_bin.tar.gz
 20,latest,macos,x64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_macos-x64_bin.tar.gz
 20,latest,windows,x64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_windows-x64_bin.zip
-ea,latest,linux,aarch64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_linux-aarch64_bin.tar.gz
-ea,latest,linux,x64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_linux-x64_bin.tar.gz
-ea,latest,macos,aarch64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_macos-aarch64_bin.tar.gz
-ea,latest,macos,x64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_macos-x64_bin.tar.gz
-ea,latest,windows,x64=https://download.java.net/java/early_access/jdk20/27/GPL/openjdk-20-ea+27_windows-x64_bin.zip
+21,latest,linux,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-aarch64_bin.tar.gz
+21,latest,linux,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-x64_bin.tar.gz
+21,latest,macos,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-aarch64_bin.tar.gz
+21,latest,macos,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-x64_bin.tar.gz
+21,latest,windows,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_windows-x64_bin.zip
+ea,latest,linux,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-aarch64_bin.tar.gz
+ea,latest,linux,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_linux-x64_bin.tar.gz
+ea,latest,macos,aarch64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-aarch64_bin.tar.gz
+ea,latest,macos,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_macos-x64_bin.tar.gz
+ea,latest,windows,x64=https://download.java.net/java/early_access/jdk21/1/GPL/openjdk-21-ea+1_windows-x64_bin.zip
 genzgc,latest,linux,aarch64=https://download.java.net/java/early_access/genzgc/3/openjdk-20-genzgc+3-29_linux-aarch64_bin.tar.gz
 genzgc,latest,linux,x64=https://download.java.net/java/early_access/genzgc/3/openjdk-20-genzgc+3-29_linux-x64_bin.tar.gz
 genzgc,latest,macos,aarch64=https://download.java.net/java/early_access/genzgc/3/openjdk-20-genzgc+3-29_macos-aarch64_bin.tar.gz
```