### PR TITLE
Update to Java 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project uses tags and branches for [release management](https://docs.github
 
 
 ## [Unreleased]
-_nothing notable, yet_
+- Default value of `release` input to Java `20`
 
 ## [1.3.1] - 2022-10-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JDKs built by Oracle are [Oracle JDK](https://www.oracle.com/java/technologies/d
 | Input Name            | Default Value | Description                                                     |
 |-----------------------|--------------:|-----------------------------------------------------------------|
 | `website`             |  `oracle.com` | From where the JDK should be downloaded from.                   |
-| `release`             |          `19` | Java feature release number or name of an Early-Access project. |
+| `release`             |          `20` | Java feature release number or name of an Early-Access project. |
 | `version`             |      `latest` | An explicit version of a Java release.                          |
 | `install`             |        `true` | Install the downloaded JDK archive file.                        |
 | `install-as-version`  |       _empty_ | Control the value passed as `java-version`                      |
@@ -35,7 +35,7 @@ Following values are supported:
 ### Input `release`
 
 The `release` input denotes a Java feature release number (`17`, `18`, ...) or a name of an Early-Access project (`loom`, ...).
-It defaults to the current General-Availability Release for the Java SE platform., which is `19` as of today.
+It defaults to the current General-Availability Release for the Java SE platform., which is `20` as of today.
 
 Note that websites may offer a different set of available releases.
 For example, `oracle.com` only offers releases of `17` and above; it does not offer any Early-Access releases.

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ inputs:
     required: true
     default: 'oracle.com'
   release:
-    description: 'Feature release number or project name, defaults to `19`'
+    description: 'Feature release number or project name, defaults to `20`'
     required: true
-    default: '19'
+    default: '20'
   version:
     description: 'Additional version information, defaults to `latest`'
     required: true

--- a/jdk.java.net-uri.properties
+++ b/jdk.java.net-uri.properties
@@ -1,30 +1,40 @@
 #
 # General-Availability Release
 #
+20,20.0.1,linux,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-aarch64_bin.tar.gz
+20,20.0.1,linux,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-x64_bin.tar.gz
+20,20.0.1,macos,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-aarch64_bin.tar.gz
+20,20.0.1,macos,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-x64_bin.tar.gz
+20,20.0.1,windows,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_windows-x64_bin.zip
+#
+# General-Availability Release (Alias)
+#
+20,latest,linux,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-aarch64_bin.tar.gz
+20,latest,linux,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-x64_bin.tar.gz
+20,latest,macos,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-aarch64_bin.tar.gz
+20,latest,macos,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-x64_bin.tar.gz
+20,latest,windows,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_windows-x64_bin.zip
+ga,latest,linux,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-aarch64_bin.tar.gz
+ga,latest,linux,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-x64_bin.tar.gz
+ga,latest,macos,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-aarch64_bin.tar.gz
+ga,latest,macos,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-x64_bin.tar.gz
+ga,latest,windows,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_windows-x64_bin.zip
+#
+# Soon-Archived Release
+#
 19,19.0.2,linux,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-aarch64_bin.tar.gz
 19,19.0.2,linux,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz
 19,19.0.2,macos,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz
 19,19.0.2,macos,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-x64_bin.tar.gz
 19,19.0.2,windows,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip
 #
-# General-Availability Release (Alias)
+# Soon-Archived Release (Alias)
 #
 19,latest,linux,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-aarch64_bin.tar.gz
 19,latest,linux,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz
 19,latest,macos,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz
 19,latest,macos,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-x64_bin.tar.gz
 19,latest,windows,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip
-ga,latest,linux,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-aarch64_bin.tar.gz
-ga,latest,linux,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz
-ga,latest,macos,aarch64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-aarch64_bin.tar.gz
-ga,latest,macos,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_macos-x64_bin.tar.gz
-ga,latest,windows,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_windows-x64_bin.zip
-#
-# Soon-Archived Release
-#
-#
-# Soon-Archived Release (Alias)
-#
 #
 # Early-Access Releases
 #
@@ -40,11 +50,6 @@ ga,latest,windows,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064a
 20,20-valhalla+20-75,macos,aarch64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_macos-aarch64_bin.tar.gz
 20,20-valhalla+20-75,macos,x64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_macos-x64_bin.tar.gz
 20,20-valhalla+20-75,windows,x64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_windows-x64_bin.zip
-20,20.0.1,linux,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-aarch64_bin.tar.gz
-20,20.0.1,linux,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-x64_bin.tar.gz
-20,20.0.1,macos,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-aarch64_bin.tar.gz
-20,20.0.1,macos,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-x64_bin.tar.gz
-20,20.0.1,windows,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_windows-x64_bin.zip
 21,21-ea+18,linux,aarch64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_linux-aarch64_bin.tar.gz
 21,21-ea+18,linux,x64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_linux-x64_bin.tar.gz
 21,21-ea+18,macos,aarch64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_macos-aarch64_bin.tar.gz
@@ -58,11 +63,6 @@ ga,latest,windows,x64=https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064a
 #
 # Early-Access Releases (Alias)
 #
-20.0.1,latest,linux,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-aarch64_bin.tar.gz
-20.0.1,latest,linux,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_linux-x64_bin.tar.gz
-20.0.1,latest,macos,aarch64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-aarch64_bin.tar.gz
-20.0.1,latest,macos,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_macos-x64_bin.tar.gz
-20.0.1,latest,windows,x64=https://download.java.net/java/GA/jdk20.0.1/b4887098932d415489976708ad6d1a4b/9/GPL/openjdk-20.0.1_windows-x64_bin.zip
 21,latest,linux,aarch64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_linux-aarch64_bin.tar.gz
 21,latest,linux,x64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_linux-x64_bin.tar.gz
 21,latest,macos,aarch64=https://download.java.net/java/early_access/jdk21/18/GPL/openjdk-21-ea+18_macos-aarch64_bin.tar.gz

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
 class ListOpenJavaDevelopmentKits {
 
   /** Current General-Availability release number. */
-  static final String GA = System.getProperty("GA", "19");
+  static final String GA = System.getProperty("GA", "20");
 
   /** Current Soon-Archived release number. */
-  static final String SA = System.getProperty("SA", "18");
+  static final String SA = System.getProperty("SA", "19");
 
   /** Early-Access Releases, as comma separated names. */
-  static final String EA = System.getProperty("EA", "21,20,genzgc,jextract,loom,metropolis,panama,valhalla");
+  static final String EA = System.getProperty("EA", "21,genzgc,jextract,loom,metropolis,panama,valhalla");
 
   /** Include archived releases flag. */
   static final boolean ARCHIVES = Boolean.getBoolean("ARCHIVES");

--- a/test/Test.java
+++ b/test/Test.java
@@ -29,11 +29,12 @@ public class Test {
   static void checkAllOracleJDKs() {
     System.out.println();
     System.out.println("// oracle.com - latest");
-    checkOracleJDK("19", "latest");
+    checkOracleJDK("20", "latest");
     checkOracleJDK("17", "latest");
 
     System.out.println();
     System.out.println("// oracle.com - archive");
+    Stream.of("19", "19.0.2", "19.0.2").forEach(version -> checkOracleJDK("19", version));
     Stream.of("18", "18.0.1", "18.0.1.1").forEach(version -> checkOracleJDK("18", version));
     Stream.of("17", "17.0.1", "17.0.2").forEach(version -> checkOracleJDK("17", version));
   }


### PR DESCRIPTION
JDK 20.0.1 has been released ~today~ yesterday and I've noticed some failures like [this one](https://github.com/assertj/assertj/actions/runs/4737259617/jobs/8409900027).

I've taken inspiration from #41 for a fix, I hope I covered all the needed points.