### PR TITLE
Support Java 21 / JDK 21: General Availability

### DIFF
--- a/.github/workflows/manual-java.net-all.yml
+++ b/.github/workflows/manual-java.net-all.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        release: [ 20, 19, 18 ]
+        release: [ 22, 21, 20 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'

--- a/.github/workflows/manual-oracle.com-17-archive.yml
+++ b/.github/workflows/manual-oracle.com-17-archive.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest , macos-latest, windows-latest ]
         release: [ 17 ]
-        version: [ 17, 17.0.1, 17.0.2 ]
+        version: [ 17, 17.0.1, 17.0.2, 17.0.3, 17.0.3.1, 17.0.4, 17.0.4.1, 17.0.5, 17.0.6, 17.0.7, 17.0.8 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'

--- a/.github/workflows/manual-website-release-version.yml
+++ b/.github/workflows/manual-website-release-version.yml
@@ -21,7 +21,7 @@ on:
         type: string
       install:
         description: 'Run actions/setup-java to install the downloaded JDK'
-        default: 'true'
+        default: true
         required: true
         type: boolean
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ This project uses tags and branches for [release management](https://docs.github
 
 
 ## [Unreleased]
+_nothing noteworthy, yet_
+
+## [1.3.2] - 2023-09-19
 ### Added
 - Java `22` to the list of Early-Access releases
 ### Changed
-- Default value of `release` input to Java `20`
+- Default value of `release` input to Java `21`
 
 ## [1.3.1] - 2022-10-20
 ### Added
@@ -47,7 +50,8 @@ This project uses tags and branches for [release management](https://docs.github
 ### Added
 - Initial Release
 
-[Unreleased]: https://github.com/oracle-actions/setup-java/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/oracle-actions/setup-java/compare/v1.3.2...HEAD
+[1.3.2]: https://github.com/oracle-actions/setup-java/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/oracle-actions/setup-java/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/oracle-actions/setup-java/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/oracle-actions/setup-java/compare/v1.2.0...v1.2.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JDKs built by Oracle are [Oracle JDK](https://www.oracle.com/java/technologies/d
 | Input Name            | Default Value | Description                                                     |
 |-----------------------|--------------:|-----------------------------------------------------------------|
 | `website`             |  `oracle.com` | From where the JDK should be downloaded from.                   |
-| `release`             |          `20` | Java feature release number or name of an Early-Access project. |
+| `release`             |          `21` | Java feature release number or name of an Early-Access project. |
 | `version`             |      `latest` | An explicit version of a Java release.                          |
 | `install`             |        `true` | Install the downloaded JDK archive file.                        |
 | `install-as-version`  |       _empty_ | Control the value passed as `java-version`                      |
@@ -35,7 +35,7 @@ Following values are supported:
 ### Input `release`
 
 The `release` input denotes a Java feature release number (`17`, `18`, ...) or a name of an Early-Access project (`loom`, ...).
-It defaults to the current General-Availability Release for the Java SE platform., which is `20` as of today.
+It defaults to the current General-Availability Release for the Java SE platform., which is `21` as of today.
 
 Note that websites may offer a different set of available releases.
 For example, `oracle.com` only offers releases of `17` and above; it does not offer any Early-Access releases.
@@ -91,11 +91,11 @@ The following examples use the [JDK Script Friendly URLs](https://www.oracle.com
 
 ```yaml
 steps:
-  - name: 'Set up latest Oracle JDK 17'
+  - name: 'Set up latest Oracle JDK 21'
     uses: oracle-actions/setup-java@v1
     with:
       website: oracle.com
-      release: 17
+      release: 21
 ```
 
 ### Download and install a specific version of Oracle JDK
@@ -151,7 +151,7 @@ These include the following labels: `ubuntu-latest`, `macos-latest`, and `window
 
 ## More information
 
-Make sure to check [the annoucement and the FAQ](https://inside.java/2022/03/11/setup-java/) on Inside Java.
+Make sure to check [the announcement and the FAQ](https://inside.java/2022/03/11/setup-java/) on Inside Java.
 
 ## Status
 

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ inputs:
     required: true
     default: 'oracle.com'
   release:
-    description: 'Feature release number or project name, defaults to `20`'
+    description: 'Feature release number or project name, defaults to `21`'
     required: true
-    default: '20'
+    default: '21'
   version:
     description: 'Additional version information, defaults to `latest`'
     required: true

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
 class ListOpenJavaDevelopmentKits {
 
   /** Current General-Availability release number. */
-  static final String GA = System.getProperty("GA", "20");
+  static final String GA = System.getProperty("GA", "21");
 
   /** Current Soon-Archived release number. */
-  static final String SA = System.getProperty("SA", "19");
+  static final String SA = System.getProperty("SA", "20");
 
   /** Early-Access Releases, as comma separated names. */
-  static final String EA = System.getProperty("EA", "22,21,jextract,panama,valhalla");
+  static final String EA = System.getProperty("EA", "22,jextract,valhalla");
 
   /** Include archived releases flag. */
   static final boolean ARCHIVES = Boolean.getBoolean("ARCHIVES");

--- a/test/Test.java
+++ b/test/Test.java
@@ -29,12 +29,13 @@ public class Test {
   static void checkAllOracleJDKs() {
     System.out.println();
     System.out.println("// oracle.com - latest");
-    checkOracleJDK("20", "latest");
+    checkOracleJDK("21", "latest");
     checkOracleJDK("17", "latest");
 
     System.out.println();
     System.out.println("// oracle.com - archive");
-    Stream.of("19", "19.0.2", "19.0.2").forEach(version -> checkOracleJDK("19", version));
+    Stream.of("20", "20.0.1", "20.0.2").forEach(version -> checkOracleJDK("20", version));
+    Stream.of("19", "19.0.1", "19.0.2").forEach(version -> checkOracleJDK("19", version));
     Stream.of("18", "18.0.1", "18.0.1.1").forEach(version -> checkOracleJDK("18", version));
     Stream.of("17", "17.0.1", "17.0.2").forEach(version -> checkOracleJDK("17", version));
   }


### PR DESCRIPTION
Please review these changes to support Java 21 / JDK 21: General Availability on 2023, Sept. 19th.

Once the websites (https://jdk.java.net/ and https://www.oracle.com/java/technologies/jdk-script-friendly-urls/) are updated, this PR can be undrafted, retested, and merged. After that happened, a new release of this action will be tagged as `v1.3.2`.

Closes #58