### PR TITLE
Support running action with ARM64 machines

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,10 @@ runs:
       id: download
       shell: bash
       run: |
-        JAVA=$JAVA_HOME_17_X64/bin/java
+        JAVA=$JAVA_HOME_17_ARM64/bin/java
+        if [ ! -f "$JAVA" ]; then
+          JAVA=$JAVA_HOME_17_X86/bin/java
+        fi
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java
         if [ ! -z "${{ inputs.uri }}" ]; then
           $JAVA \


### PR DESCRIPTION
Try JAVA_HOME_17_ARM64 first, and fallback to JAVA_HOME_17_X86

Fixes https://github.com/oracle-actions/setup-java/issues/63