### PR TITLE
Change email address used by update workflow

### DIFF
--- a/.github/workflows/jdk.java.net-uri-update.yml
+++ b/.github/workflows/jdk.java.net-uri-update.yml
@@ -13,7 +13,7 @@ jobs:
       - run: $JAVA_HOME_17_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
       - run: |
           git diff
-          git config user.name Oracle GitHub Actions
+          git config user.name github_actions_dev
           git config user.email github_actions_dev_grp@oracle.com
           git add .
           if [ -z "$(git status --porcelain)" ]; then

--- a/.github/workflows/jdk.java.net-uri-update.yml
+++ b/.github/workflows/jdk.java.net-uri-update.yml
@@ -13,8 +13,8 @@ jobs:
       - run: $JAVA_HOME_17_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
       - run: |
           git diff
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name Oracle GitHub Actions
+          git config user.email github_actions_dev_grp@oracle.com
           git add .
           if [ -z "$(git status --porcelain)" ]; then
             echo 'No changes detected.'


### PR DESCRIPTION
Use `github_actions_dev_grp@oracle.com` as the git email when updating the list of JDK kits hosted at https://jdk.java.net