### PR TITLE
Feat: Add support for M1 MAC runners

### DIFF
--- a/.github/workflows/jdk.java.net-uri-list.yml
+++ b/.github/workflows/jdk.java.net-uri-list.yml
@@ -11,4 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: $JAVA_HOME_17_X64/bin/java --show-version src/ListOpenJavaDevelopmentKits.java ${{ github.event.inputs.name }}
+      - run: |
+          source src/res/set_java_home.sh
+          set_java_home_env
+          ${!JAVA_HOME_ENV}/bin/java --show-version src/ListOpenJavaDevelopmentKits.java ${{ github.event.inputs.name }}

--- a/.github/workflows/jdk.java.net-uri-update.yml
+++ b/.github/workflows/jdk.java.net-uri-update.yml
@@ -10,7 +10,10 @@ jobs:
     steps:
       - run: curl --output /dev/null --silent --head --fail https://jdk.java.net
       - uses: actions/checkout@v4
-      - run: $JAVA_HOME_17_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
+      - run: |
+          source src/res/set_java_home.sh
+          set_java_home_env
+          ${!JAVA_HOME_ENV}/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
       - run: |
           git diff
           git config user.name github_actions_dev

--- a/.github/workflows/manual-java.net-all.yml
+++ b/.github/workflows/manual-java.net-all.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest, macos-14 ]
         release: [ 22, 21, 20 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/manual-java.net-ea-latest.yml
+++ b/.github/workflows/manual-java.net-ea-latest.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ ubuntu-latest , macos-latest, windows-latest ]
+        os: [ ubuntu-latest , macos-latest, windows-latest, macos-14 ]
         release: [ 'ea' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
       - name: 'Compile and run test'
         shell: bash
         run: |
-          PATH=$JAVA_HOME_17_X64/bin:$PATH
+          source src/res/set_java_home.sh
+          set_java_home_env
+          PATH=${!JAVA_HOME_ENV}/bin:$PATH
           javac -d classes src/Download.java test/Test.java
           java -cp classes Test
   validate:
@@ -27,5 +29,7 @@ jobs:
       - name: 'Run validation program'
         shell: bash
         run: |
-          PATH=$JAVA_HOME_17_X64/bin:$PATH
+          source src/res/set_java_home.sh
+          set_java_home_env
+          PATH=${!JAVA_HOME_ENV}/bin:$PATH
           java test/Validate.java

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,9 @@ runs:
       id: download
       shell: bash
       run: |
-        JAVA=$JAVA_HOME_17_X64/bin/java
+        source src/res/set_java_home.sh
+        set_java_home_env
+        JAVA="${!JAVA_HOME_ENV}/bin/java"
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java
         if [ ! -z "${{ inputs.uri }}" ]; then
           $JAVA \

--- a/src/res/set_java_home.sh
+++ b/src/res/set_java_home.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set_java_home_env() {
+  if [ "$RUNNER_ARCH" = "ARM64" ]; then
+    ARCH="arm64"
+  else
+    ARCH="$RUNNER_ARCH"
+  fi
+  JAVA_HOME_ENV="JAVA_HOME_17_${ARCH}"
+}


### PR DESCRIPTION
Github action recently added support for MacOS M1 runner (https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) and is free for public repos. Since the action script hardcoded `JAVA_HOME` for `x86` arch, tit won't run on `ARM64` machines. This PR will fix that.