### PR TITLE
Support running on ARM64 machines

### DIFF
--- a/.github/workflows/manual-uri.yml
+++ b/.github/workflows/manual-uri.yml
@@ -9,6 +9,7 @@ on:
         options:
           - 'ubuntu-latest'
           - 'macos-latest'
+          - 'macos-14'
           - 'windows-latest'
       uri:
         description: 'URI of JDK archive file to download'

--- a/.github/workflows/manual-website-release-version.yml
+++ b/.github/workflows/manual-website-release-version.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, macos-14, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project uses tags and branches for [release management](https://docs.github
 
 
 ## [Unreleased]
-_nothing noteworthy, yet_
+### Fixed
+- Support running on ARM64 machines [#63](https://github.com/oracle-actions/setup-java/issues/63)
 
 ## [1.3.3] - 2024-01-29
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,9 @@ runs:
       run: |
         JAVA=$JAVA_HOME_17_X64/bin/java
         if [ ! -d "$JAVA_HOME_17_X64" ]; then
-          JAVA=$JAVA_HOME_17_ARM64/bin/java
+          JAVA=$JAVA_HOME_17_arm64/bin/java
         fi
+        $JAVA --version
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java
         if [ ! -z "${{ inputs.uri }}" ]; then
           $JAVA \

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ runs:
       shell: bash
       run: |
         JAVA=$JAVA_HOME_17_X64/bin/java
+        if [ ! -d "$JAVA_HOME_17_X64" ]; then
+          JAVA=$JAVA_HOME_17_ARM64/bin/java
+        fi
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java
         if [ ! -z "${{ inputs.uri }}" ]; then
           $JAVA \


### PR DESCRIPTION
This PR implements support for running this action on ARM64 machines, including the new "macOS 14 (Sonoma)" runner: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

Testing for existence of the Java installation directory instead of the `java[.exe]` file should work on Windows runners, too.

Closes #63 
Supersedes #64 and #71