### PR TITLE
Run action with Java 21

### DIFF
--- a/.github/workflows/jdk.java.net-uri-list.yml
+++ b/.github/workflows/jdk.java.net-uri-list.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: $JAVA_HOME_17_X64/bin/java --show-version src/ListOpenJavaDevelopmentKits.java ${{ github.event.inputs.name }}
+      - run: $JAVA_HOME_21_X64/bin/java --show-version src/ListOpenJavaDevelopmentKits.java ${{ github.event.inputs.name }}

--- a/.github/workflows/jdk.java.net-uri-update.yml
+++ b/.github/workflows/jdk.java.net-uri-update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - run: curl --output /dev/null --verbose --head --fail https://jdk.java.net
       - uses: actions/checkout@v4
-      - run: $JAVA_HOME_17_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
+      - run: $JAVA_HOME_21_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
       - run: |
           git diff
           git config user.name github_actions_dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Compile and run test'
         shell: bash
         run: |
-          PATH=$JAVA_HOME_17_X64/bin:$PATH
+          PATH=$JAVA_HOME_21_X64/bin:$PATH
           javac -d classes src/Download.java test/Test.java
           java -cp classes Test
   validate:
@@ -27,5 +27,5 @@ jobs:
       - name: 'Run validation program'
         shell: bash
         run: |
-          PATH=$JAVA_HOME_17_X64/bin:$PATH
+          PATH=$JAVA_HOME_21_X64/bin:$PATH
           java test/Validate.java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ This project uses tags and branches for [release management](https://docs.github
 
 ## [Unreleased]
 ### Fixed
-- Support running on ARM64 machines [#63](https://github.com/oracle-actions/setup-java/issues/63)
+- Support running on ARM64 machines
 ### Changed
 - Default value of `release` input to Java `22`
+- Run action with pre-installed Java 21
 
 ## [1.3.3] - 2024-01-29
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -46,9 +46,9 @@ runs:
       id: download
       shell: bash
       run: |
-        JAVA=$JAVA_HOME_17_X64/bin/java
-        if [ ! -d "$JAVA_HOME_17_X64" ]; then
-          JAVA=$JAVA_HOME_17_arm64/bin/java
+        JAVA=$JAVA_HOME_21_X64/bin/java
+        if [ ! -d "$JAVA_HOME_21_X64" ]; then
+          JAVA=$JAVA_HOME_21_arm64/bin/java
         fi
         $JAVA --version
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java


### PR DESCRIPTION
Please review this change to use pre-installed Java 21 to run actions via `JAVA_HOME_21_X64` or `JAVA_HOME_21_arm64`.

Closes #76