### PR TITLE
Support stable EA builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project uses tags and branches for [release management](https://docs.github
 
 
 ## [Unreleased]
+### Added
+- Java `23` and `24` to the list of Early-Access releases
+- New `version: stable` mode for `release: ea` setups
 
 ## [1.3.4] - 2024-03-21
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ It is set by default to `latest`.
 
 ___
 
-**WARNING!**
-
-Older versions of the JDK are provided to help developers debug issues in older systems.
-**They are not updated with the latest security patches and are not recommended for use in production.**
+> [!CAUTION]
+> Older versions of the JDK are provided to help developers debug issues in older systems.
+> **They are not updated with the latest security patches and are not recommended for use in production.**
 
 ___
 
@@ -111,10 +110,9 @@ steps:
 ```
 ___
 
-**WARNING!**
-
-Older versions of the JDK are provided to help developers debug issues in older systems.
-**They are not updated with the latest security patches and are not recommended for use in production.**
+> [!CAUTION]
+> Older versions of the JDK are provided to help developers debug issues in older systems.
+> **They are not updated with the latest security patches and are not recommended for use in production.**
 
 ___
 
@@ -132,6 +130,11 @@ steps:
       website: jdk.java.net
       release: N # Replace N with GA, EA, 17, 18, 19, ...
 ```
+
+> [!NOTE]
+> This action supports two `version` update early-access modes for `release: EA` on `jdk.java.net`:
+>   - `version: latest` updates as early as possible to the latest-and-greatest JDK build (default)
+>   - `version: stable` updates later in the release cycle, usually then a new JDK build goes GA
 
 ### Download and install an Early-Access build of a named OpenJDK project
 

--- a/jdk.java.net-uri.properties
+++ b/jdk.java.net-uri.properties
@@ -20,6 +20,12 @@ ga,latest,macos,aarch64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb
 ga,latest,macos,x64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_macos-x64_bin.tar.gz
 ga,latest,windows,x64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_windows-x64_bin.zip
 #
+# Soon-Archived Release
+#
+#
+# Soon-Archived Release (Alias)
+#
+#
 # Early-Access Releases
 #
 20,20-valhalla+20-75,linux,aarch64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_linux-aarch64_bin.tar.gz
@@ -64,11 +70,6 @@ ea,latest,linux,x64=https://download.java.net/java/early_access/jdk24/1/GPL/open
 ea,latest,macos,aarch64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_macos-aarch64_bin.tar.gz
 ea,latest,macos,x64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_macos-x64_bin.tar.gz
 ea,latest,windows,x64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_windows-x64_bin.zip
-ea,stable,linux,aarch64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_linux-aarch64_bin.tar.gz
-ea,stable,linux,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_linux-x64_bin.tar.gz
-ea,stable,macos,aarch64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_macos-aarch64_bin.tar.gz
-ea,stable,macos,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_macos-x64_bin.tar.gz
-ea,stable,windows,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_windows-x64_bin.zip
 jextract,latest,linux,x64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_linux-x64_bin.tar.gz
 jextract,latest,macos,aarch64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_macos-aarch64_bin.tar.gz
 jextract,latest,macos,x64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_macos-x64_bin.tar.gz

--- a/jdk.java.net-uri.properties
+++ b/jdk.java.net-uri.properties
@@ -20,12 +20,6 @@ ga,latest,macos,aarch64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb
 ga,latest,macos,x64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_macos-x64_bin.tar.gz
 ga,latest,windows,x64=https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_windows-x64_bin.zip
 #
-# Soon-Archived Release
-#
-#
-# Soon-Archived Release (Alias)
-#
-#
 # Early-Access Releases
 #
 20,20-valhalla+20-75,linux,aarch64=https://download.java.net/java/early_access/valhalla/20/openjdk-20-valhalla+20-75_linux-aarch64_bin.tar.gz
@@ -70,6 +64,11 @@ ea,latest,linux,x64=https://download.java.net/java/early_access/jdk24/1/GPL/open
 ea,latest,macos,aarch64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_macos-aarch64_bin.tar.gz
 ea,latest,macos,x64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_macos-x64_bin.tar.gz
 ea,latest,windows,x64=https://download.java.net/java/early_access/jdk24/1/GPL/openjdk-24-ea+1_windows-x64_bin.zip
+ea,stable,linux,aarch64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_linux-aarch64_bin.tar.gz
+ea,stable,linux,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_linux-x64_bin.tar.gz
+ea,stable,macos,aarch64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_macos-aarch64_bin.tar.gz
+ea,stable,macos,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_macos-x64_bin.tar.gz
+ea,stable,windows,x64=https://download.java.net/java/early_access/jdk23/26/GPL/openjdk-23-ea+26_windows-x64_bin.zip
 jextract,latest,linux,x64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_linux-x64_bin.tar.gz
 jextract,latest,macos,aarch64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_macos-aarch64_bin.tar.gz
 jextract,latest,macos,x64=https://download.java.net/java/early_access/jextract/22/5/openjdk-22-jextract+5-33_macos-x64_bin.tar.gz

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -140,18 +140,16 @@ class ListOpenJavaDevelopmentKits {
       var from = version.indexOf('-');
       var till = version.indexOf('+');
       var project = from >= 0 && from < till ? version.substring(from + 1, till) : version;
-      if (project.equals("ea")) {
-        components[0] = release;
-        components[1] = "latest";
-        var aliasWithReleaseFeatureNumber = String.join(",", components);
-        components[0] = "ea";
-        components[1] = release.equals(EA_STABLE) ? "stable" : "latest";
-        var aliasWithEarlyAccessTag = String.join(",", components);
-        return List.of(aliasWithReleaseFeatureNumber, aliasWithEarlyAccessTag);
-      }
-      components[0] = project;
+      components[0] = project; // "ea", "loom", ...
       components[1] = "latest";
-      return List.of(String.join(",", components));
+      if (!project.equals("ea")) return List.of(String.join(",", components));
+      components[0] = "ea";
+      components[1] = release.equals(EA_STABLE) ? "stable" : "latest";
+      var aliasWithEarlyAccessMode = String.join(",", components);
+      components[0] = release; // "23", "24", ...
+      components[1] = "latest";
+      var aliasWithReleaseFeatureNumber = String.join(",", components);
+      return List.of(aliasWithReleaseFeatureNumber, aliasWithEarlyAccessMode);
     } catch (IndexOutOfBoundsException exception) {
       System.err.println("Early-Access version without `-` and `+`: " + version);
       return List.of();

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -47,6 +47,9 @@ class ListOpenJavaDevelopmentKits {
   /** Early-Access Releases, as comma separated names. */
   static final String EA = System.getProperty("EA", "24,23,jextract,loom,valhalla");
 
+  /** Current "stable" Early-Access Release number. */
+  static final String EA_STABLE = "23";
+
   /** Include archived releases flag. */
   static final boolean ARCHIVES = Boolean.getBoolean("ARCHIVES");
 
@@ -137,12 +140,18 @@ class ListOpenJavaDevelopmentKits {
       var from = version.indexOf('-');
       var till = version.indexOf('+');
       var project = from >= 0 && from < till ? version.substring(from + 1, till) : version;
+      if (project.equals("ea")) {
+        components[0] = release;
+        components[1] = "latest";
+        var aliasWithReleaseFeatureNumber = String.join(",", components);
+        components[0] = "ea";
+        components[1] = release.equals(EA_STABLE) ? "stable" : "latest";
+        var aliasWithEarlyAccessTag = String.join(",", components);
+        return List.of(aliasWithReleaseFeatureNumber, aliasWithEarlyAccessTag);
+      }
       components[0] = project;
       components[1] = "latest";
-      var alias = String.join(",", components);
-      if (!project.equals("ea")) return List.of(alias);
-      components[0] = release; // 18-latest-...
-      return List.of(alias, String.join(",", components));
+      return List.of(String.join(",", components));
     } catch (IndexOutOfBoundsException exception) {
       System.err.println("Early-Access version without `-` and `+`: " + version);
       return List.of();


### PR DESCRIPTION
Please review this change that adds support for a `ea,stable,...` alias key. Usage in workflow files would look like this:

```yaml
      - name: 'Set up stable EA JDK'
        uses: oracle-actions/setup-java@v1
        with:
          website: jdk.java.net
          release: ea
          version: stable
```

Closes #82