### PR TITLE
100: Expand shell variables earlier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,12 @@ runs:
     - name: 'Download Java Development Kit'
       id: download
       shell: bash
+      env:
+        WEBSITE: "${{ inputs.website }}"
+        RELEASE: "${{ inputs.release }}"
+        VERSION: "${{ inputs.version }}"
+        INSTALL_AS_VERSION: "${{ inputs.install-as-version }}"
+        URI: "${{ inputs.uri }}"
       run: |
         echo "::group::Prepare download..."
         JAVA=$JAVA_HOME_21_X64/bin/java
@@ -54,18 +60,18 @@ runs:
         $JAVA --version
         DOWNLOAD=$GITHUB_ACTION_PATH/src/Download.java
         echo "::endgroup::"
-        if [ ! -z "${{ inputs.uri }}" ]; then
+        if [ ! -z "$URI" ]; then
           $JAVA \
-            -Dinstall-as-version="${{ inputs.install-as-version }}" \
+            -Dinstall-as-version="$INSTALL_AS_VERSION" \
             $DOWNLOAD \
-            ${{ inputs.uri }}
+            $URI
         else
           $JAVA \
-            -Dinstall-as-version="${{ inputs.install-as-version }}" \
+            -Dinstall-as-version="$INSTALL_AS_VERSION" \
             $DOWNLOAD \
-            ${{ inputs.website }} \
-            ${{ inputs.release }} \
-            ${{ inputs.version }}
+            $WEBSITE \
+            $RELEASE \
+            $VERSION
         fi
     - name: 'Install Java Development Kit'
       if: ${{ inputs.install  == 'true' }}

--- a/test/Test.java
+++ b/test/Test.java
@@ -30,7 +30,6 @@ public class Test {
     System.out.println();
     System.out.println("// oracle.com - latest");
     checkOracleJDK("24", "latest");
-    checkOracleJDK("23", "latest");
     checkOracleJDK("21", "latest");
 
     System.out.println();


### PR DESCRIPTION
Expand shell variables earlier by switching to using environment variables and referencing them in the bash commands from that rather than directly interpolating the variables.

Closes #100