### PR TITLE
Update `actions/checkout` and `actions/setup-java`, apply SHA pinning

### DIFF
--- a/.github/workflows/jdk.java.net-uri-list.yml
+++ b/.github/workflows/jdk.java.net-uri-list.yml
@@ -10,5 +10,5 @@ jobs:
   list:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: $JAVA_HOME_21_X64/bin/java --show-version src/ListOpenJavaDevelopmentKits.java ${{ github.event.inputs.name }}

--- a/.github/workflows/jdk.java.net-uri-update.yml
+++ b/.github/workflows/jdk.java.net-uri-update.yml
@@ -9,7 +9,7 @@ jobs:
     permissions: write-all
     steps:
       - run: curl --output /dev/null --verbose --head --fail https://jdk.java.net
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: $JAVA_HOME_21_X64/bin/java src/ListOpenJavaDevelopmentKits.java > jdk.java.net-uri.properties
       - run: |
           git diff

--- a/.github/workflows/manual-all-environments.yml
+++ b/.github/workflows/manual-all-environments.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up default JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-java.net-all.yml
+++ b/.github/workflows/manual-java.net-all.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-java.net-ea-latest.yml
+++ b/.github/workflows/manual-java.net-ea-latest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-oracle.com-17-archive.yml
+++ b/.github/workflows/manual-oracle.com-17-archive.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-oracle.com-17-latest.yml
+++ b/.github/workflows/manual-oracle.com-17-latest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-uri.yml
+++ b/.github/workflows/manual-uri.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ github.event.inputs.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/manual-website-release-version.yml
+++ b/.github/workflows/manual-website-release-version.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Set up JDK'
         id: setup
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Compile and run test'
         shell: bash
         run: |
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: 'Run validation program'
         shell: bash
         run: |

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
         fi
     - name: 'Install Java Development Kit'
       if: ${{ inputs.install  == 'true' }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
       with:
         java-version: ${{ steps.download.outputs.version }}
         distribution: jdkfile


### PR DESCRIPTION
Prior to this change, projects using `oracle-actions/setup-java` and having [SHA pinning enforced](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning) would fail despite pinning the `oracle-actions/setup-java` version. This is because `oracle-actions/setup-java` uses `actions/setup-java` under the hood without pinning.

This change updates all used actions to the latest versions and also applies SHA pinning to them.

* Closes #105