### PR TITLE
Java 26 / JDK 26: General Availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ This project uses tags and branches for [release management](https://docs.github
 
 ## [Unreleased]
 ### Changed
-- Update version of `actions/checkout` to `v6.0.1`
-- Update version of `actions/setup-java` to `v5.2.0`
+- Default value of `release` input to Java `26`
 
 ## [1.5.0] - 2025-09-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JDKs built by Oracle are [Oracle JDK](https://www.oracle.com/java/technologies/d
 | Input Name            | Default Value | Description                                                     |
 |-----------------------|--------------:|-----------------------------------------------------------------|
 | `website`             |  `oracle.com` | From where the JDK should be downloaded.                        |
-| `release`             |          `25` | Java feature release number or name of an Early-Access project. |
+| `release`             |          `26` | Java feature release number or name of an Early-Access project. |
 | `version`             |      `latest` | An explicit version of a Java release.                          |
 | `install`             |        `true` | Install the downloaded JDK archive file.                        |
 | `install-as-version`  |       _empty_ | Control the value passed as `java-version`                      |
@@ -90,23 +90,22 @@ The following examples use the [JDK Script Friendly URLs](https://www.oracle.com
 
 ```yaml
 steps:
-  - name: 'Set up latest Oracle JDK 25'
+  - name: 'Set up latest Oracle JDK'
     uses: oracle-actions/setup-java@v1
     with:
       website: oracle.com
-      release: 25
 ```
 
 ### Download and install a specific version of Oracle JDK
 
 ```yaml
 steps:
-  - name: 'Set up archived Oracle JDK 21.0.4'
+  - name: 'Set up archived Oracle JDK 25.0.2'
     uses: oracle-actions/setup-java@v1
     with:
       website: oracle.com
-      release: 21
-      version: 21.0.4
+      release: 25
+      version: 25.0.2
 ```
 ___
 

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ inputs:
     required: true
     default: 'oracle.com'
   release:
-    description: 'Feature release number or project name, defaults to `25`'
+    description: 'Feature release number or project name, defaults to `26`'
     required: true
-    default: '25'
+    default: '26'
   version:
     description: 'Additional version information, defaults to `latest`'
     required: true

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -40,26 +40,24 @@ class ListOpenJavaDevelopmentKits {
   static final List<Page> PAGES =
       List.of(
           // JDK: General-Availability Release
-          Page.of("25") // https://jdk.java.net/25
-              .withAlias("25,latest")
-              .withAlias("ga,latest"),
-          // JDK: Early-Access Releases
           Page.of("26") // https://jdk.java.net/26
               .withAlias("26,latest")
-              .withAlias("ea,stable"),
+              .withAlias("ga,latest"),
+          // JDK: Early-Access Releases
           Page.of("27") // https://jdk.java.net/27
               .withAlias("27,latest")
-              .withAlias("ea,latest"),
+              .withAlias("ea,latest")
+              .withAlias("ea,stable"),
           // Named projects, usually in EA phase
           Page.of("jextract") // https://jdk.java.net/jextract
               .withAlias("jextract,latest")
               .withAlias("jextract,ea"),
+          Page.of("leyden") // https://jdk.java.net/leyden
+              .withAlias("leyden,latest")
+             .withAlias("leyden,ea"),
           Page.of("loom") // https://jdk.java.net/loom
               .withAlias("loom,latest")
               .withAlias("loom,ea"),
-          Page.of("leyden") // https://jdk.java.net/leyden
-              .withAlias("leyden,latest")
-              .withAlias("leyden,ea"),
           Page.of("valhalla") // https://jdk.java.net/valhalla
               .withAlias("valhalla,latest")
               .withAlias("valhalla,ea"));

--- a/src/ListOpenJavaDevelopmentKits.java
+++ b/src/ListOpenJavaDevelopmentKits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates.
  *
  * This source code is licensed under the UPL license found in the
  * LICENSE.txt file in the root directory of this source tree.

--- a/test/Test.java
+++ b/test/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates.
  *
  * This source code is licensed under the UPL license found in the
  * LICENSE.txt file in the root directory of this source tree.
@@ -35,14 +35,13 @@ public class Test {
 
     System.out.println();
     System.out.println("// oracle.com - archive");
-    Stream.of("25", "25.0.1").forEach(version -> checkOracleJDK("25", version));
-    Stream.of("24", "24.0.1").forEach(version -> checkOracleJDK("24", version));
-    Stream.of("23", "23.0.1").forEach(version -> checkOracleJDK("23", version));
-    Stream.of("22", "22.0.1", "22.0.2").forEach(version -> checkOracleJDK("22", version));
-    Stream.of("21", "21.0.1", "21.0.2", "21.0.4").forEach(version -> checkOracleJDK("21", version));
-    Stream.of("20", "20.0.1", "20.0.2").forEach(version -> checkOracleJDK("20", version));
-    Stream.of("19", "19.0.1", "19.0.2").forEach(version -> checkOracleJDK("19", version));
-    Stream.of("18", "18.0.1", "18.0.1.1").forEach(version -> checkOracleJDK("18", version));
+    Stream.of("25", "25.0.1", "25.0.2").forEach(version -> checkOracleJDK("25", version));
+    Stream.of("21", "21.0.1", "21.0.2", "21.0.10").forEach(version -> checkOracleJDK("21", version));
+    /*
+     * The Oracle Technology Network License Agreement for Oracle Java SE used for
+     * JDK 17 updates 17.0.13 and greater is substantially different from prior
+     * Oracle JDK 17 licenses.
+     */
     Stream.of("17", "17.0.1", "17.0.2", "17.0.12").forEach(version -> checkOracleJDK("17", version));
   }
 
@@ -63,7 +62,10 @@ public class Test {
 
     System.out.println();
     System.out.println("// jdk.java.net - Project Leyden - latest");
-    checkJavaNetJDK("leyden", "latest");
+    // checkJavaNetJDK("leyden", "latest"); // only the following binaries are available
+    checkJDK("jdk.java.net", new Download.JDK("leyden", "latest", "linux", "aarch64", "tar.gz"));
+    checkJDK("jdk.java.net", new Download.JDK("leyden", "latest", "linux", "x64", "tar.gz"));
+    checkJDK("jdk.java.net", new Download.JDK("leyden", "latest", "macos", "aarch64", "tar.gz"));
 
     System.out.println();
     System.out.println("// jdk.java.net - Project Loom - latest");
@@ -83,7 +85,9 @@ public class Test {
   }
 
   static void checkJavaNetJDK(String release, String version) {
+    checkJDK("jdk.java.net", new Download.JDK(release, version, "linux", "aarch64", "tar.gz"));
     checkJDK("jdk.java.net", new Download.JDK(release, version, "linux", "x64", "tar.gz"));
+    checkJDK("jdk.java.net", new Download.JDK(release, version, "macos", "aarch64", "tar.gz"));
     checkJDK("jdk.java.net", new Download.JDK(release, version, "macos", "x64", "tar.gz"));
     checkJDK("jdk.java.net", new Download.JDK(release, version, "windows", "x64", "zip"));
   }

--- a/test/Test.java
+++ b/test/Test.java
@@ -29,6 +29,7 @@ public class Test {
   static void checkAllOracleJDKs() {
     System.out.println();
     System.out.println("// oracle.com - latest");
+    checkOracleJDK("26", "latest");
     checkOracleJDK("25", "latest");
     checkOracleJDK("21", "latest");
 
@@ -55,6 +56,18 @@ public class Test {
     checkJavaNetJDK("ea", "latest");
     System.out.println("// jdk.java.net - EA - stable");
     checkJavaNetJDK("ea", "stable");
+
+    System.out.println();
+    System.out.println("// jdk.java.net - Project JExtract - latest");
+    checkJavaNetJDK("jextract", "latest");
+
+    System.out.println();
+    System.out.println("// jdk.java.net - Project Leyden - latest");
+    checkJavaNetJDK("leyden", "latest");
+
+    System.out.println();
+    System.out.println("// jdk.java.net - Project Loom - latest");
+    checkJavaNetJDK("loom", "latest");
 
     System.out.println();
     System.out.println("// jdk.java.net - Project Valhalla - latest");

--- a/test/Test.java
+++ b/test/Test.java
@@ -57,7 +57,7 @@ public class Test {
     checkJavaNetJDK("ea", "stable");
 
     System.out.println();
-    System.out.println("// jdk.java.net - Project JExtract - latest");
+    System.out.println("// jdk.java.net - Project Jextract - latest");
     checkJavaNetJDK("jextract", "latest");
 
     System.out.println();


### PR DESCRIPTION
On 2026-03-17, the following links started to work:

```
(HEAD https://download.oracle.com/java/26/latest/jdk-26_linux-aarch64_bin.tar.gz) 404
(HEAD https://download.oracle.com/java/26/latest/jdk-26_linux-x64_bin.tar.gz) 404
(HEAD https://download.oracle.com/java/26/latest/jdk-26_macos-aarch64_bin.tar.gz) 404
(HEAD https://download.oracle.com/java/26/latest/jdk-26_macos-x64_bin.tar.gz) 404
(HEAD https://download.oracle.com/java/26/latest/jdk-26_windows-x64_bin.zip) 404
```

Closes #113